### PR TITLE
Updated the Join to take into account if the tasks have been complete but don't match join condition.

### DIFF
--- a/SpiffWorkflow/specs/Join.py
+++ b/SpiffWorkflow/specs/Join.py
@@ -148,7 +148,7 @@ class Join(TaskSpec):
 
             # For any conditional tasks - make sure if they were completed
             # their condition matched the Join connect_if - otherwise skip
-            if not self._task_matches_condidition(task):
+            if not self._task_matches_condition(task):
                 continue
 
             if task.parent is None or task._has_state(Task.COMPLETED):
@@ -159,7 +159,7 @@ class Join(TaskSpec):
         # If the threshold was reached, get ready to fire.
         return force or completed >= threshold, waiting_tasks
 
-    def _task_matches_condidition(self, task):
+    def _task_matches_condition(self, task):
         # If the task had any conditional make sure the conditions were met
         has_conditions = hasattr(task.task_spec, 'cond_task_specs')
         if not has_conditions:
@@ -191,7 +191,7 @@ class Join(TaskSpec):
 
             # For any conditional tasks - make sure if they were completed
             # their condition matched the Join connect_if - otherwise skip
-            if not self._task_matches_condidition(task):
+            if not self._task_matches_condition(task):
                 continue
 
             if not self._branch_may_merge_at(task):

--- a/SpiffWorkflow/specs/Join.py
+++ b/SpiffWorkflow/specs/Join.py
@@ -148,7 +148,7 @@ class Join(TaskSpec):
 
             # For any conditional tasks - make sure if they were completed
             # their condition matched the Join connect_if - otherwise skip
-            if not self._task_matches_condition(task):
+            if task._has_state(Task.COMPLETED) and not self._task_matches_condition(task):
                 continue
 
             if task.parent is None or task._has_state(Task.COMPLETED):
@@ -191,14 +191,14 @@ class Join(TaskSpec):
 
             # For any conditional tasks - make sure if they were completed
             # their condition matched the Join connect_if - otherwise skip
-            if not self._task_matches_condition(task):
+            if task._has_state(Task.COMPLETED) and not self._task_matches_condition(task):
                 continue
 
             if not self._branch_may_merge_at(task):
                 completed += 1
             elif self._branch_is_complete(task):
                 completed += 1
-            else:
+            elif not task._has_state(Task.COMPLETED) :
                 waiting_tasks.append(task)
 
         # If the threshold was reached, get ready to fire.

--- a/tests/SpiffWorkflow/specs/JoinTest.py
+++ b/tests/SpiffWorkflow/specs/JoinTest.py
@@ -26,7 +26,7 @@ class JoinTest(TaskSpecTest):
                     'testtask',
                     description='foo')
 
-    def setup_worflow(self, structured=True):
+    def setup_workflow(self, structured=True):
         wf_spec = WorkflowSpec()
         split = Simple(wf_spec, 'split')
         wf_spec.start.connect(split)
@@ -58,7 +58,7 @@ class JoinTest(TaskSpecTest):
         are complete AND they were completed with the correct condition to
         satisfy the join"""
 
-        workflow = self.setup_worflow()
+        workflow = self.setup_workflow()
 
         workflow.complete_task_from_id(
             workflow.get_tasks_from_spec_name('split')[0].id)
@@ -78,7 +78,7 @@ class JoinTest(TaskSpecTest):
             are complete AND they were completed with the correct condition to
             satisfy the join"""
 
-        workflow = self.setup_worflow(structured=False)
+        workflow = self.setup_workflow(structured=False)
 
         workflow.complete_task_from_id(
             workflow.get_tasks_from_spec_name('split')[0].id)
@@ -98,7 +98,7 @@ class JoinTest(TaskSpecTest):
             are complete AND they were completed with the correct condition to
             satisfy the join"""
 
-        workflow = self.setup_worflow()
+        workflow = self.setup_workflow()
 
         workflow.complete_task_from_id(
             workflow.get_tasks_from_spec_name('split')[0].id)
@@ -118,7 +118,7 @@ class JoinTest(TaskSpecTest):
             are complete AND they were completed with the correct condition to
             satisfy the join"""
 
-        workflow = self.setup_worflow(structured=False)
+        workflow = self.setup_workflow(structured=False)
 
         workflow.complete_task_from_id(
             workflow.get_tasks_from_spec_name('split')[0].id)

--- a/tests/SpiffWorkflow/specs/JoinTest.py
+++ b/tests/SpiffWorkflow/specs/JoinTest.py
@@ -5,11 +5,14 @@ from __future__ import division
 import os
 import sys
 import unittest
+
+from SpiffWorkflow.operators import Attrib, Equal
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..'))
 
 from .TaskSpecTest import TaskSpecTest
-from SpiffWorkflow.specs import Join
-from SpiffWorkflow import Workflow
+from SpiffWorkflow.specs import Join, WorkflowSpec, Simple, ExclusiveChoice
+from SpiffWorkflow import Workflow, Task
 
 
 class JoinTest(TaskSpecTest):
@@ -23,6 +26,112 @@ class JoinTest(TaskSpecTest):
                     'testtask',
                     description='foo')
 
+    def setup_worflow(self, structured=True):
+        wf_spec = WorkflowSpec()
+        split = Simple(wf_spec, 'split')
+        wf_spec.start.connect(split)
+
+        if structured:
+            join = Join(wf_spec, 'join', split_task=split.name)
+        else:
+            join = Join(wf_spec, 'join')
+
+        single = Simple(wf_spec, 'first')
+        default = Simple(wf_spec, 'default')
+        choice = ExclusiveChoice(wf_spec, 'choice', manual=True)
+        end = Simple(wf_spec, 'end')
+
+        single.connect(join)
+        join_condition = Equal(Attrib('should_join'), True)
+        choice.connect_if(join_condition, join)
+        choice.connect(default)
+
+        split.connect(single)
+        split.connect(choice)
+        join.connect(end)
+
+        workflow = Workflow(wf_spec)
+        return workflow
+
+    def test_join_complete_status_structured(self):
+        """ Test that a join is not considered complete if the all the tasks
+        are complete AND they were completed with the correct condition to
+        satisfy the join"""
+
+        workflow = self.setup_worflow()
+
+        workflow.complete_task_from_id(
+            workflow.get_tasks_from_spec_name('split')[0].id)
+        workflow.complete_task_from_id(
+            workflow.get_tasks_from_spec_name('first')[0].id)
+        # Complete the choice task but set the data to match the join condition
+        choice_task = workflow.get_tasks_from_spec_name('choice')[0]
+        choice_task.set_data(should_join=True)
+        workflow.complete_task_from_id(choice_task.id)
+
+        # Join should be in completed state
+        self.assertEqual(Task.COMPLETED,
+                         workflow.get_tasks_from_spec_name('join')[0].state)
+
+    def test_join_complete_status_unstructured(self):
+        """ Test that a join is not considered complete if the all the tasks
+            are complete AND they were completed with the correct condition to
+            satisfy the join"""
+
+        workflow = self.setup_worflow(structured=False)
+
+        workflow.complete_task_from_id(
+            workflow.get_tasks_from_spec_name('split')[0].id)
+        workflow.complete_task_from_id(
+            workflow.get_tasks_from_spec_name('first')[0].id)
+        # Complete the choice task but set the data to match the join condition
+        choice_task = workflow.get_tasks_from_spec_name('choice')[0]
+        choice_task.set_data(should_join=True)
+        workflow.complete_task_from_id(choice_task.id)
+
+        # Join should be in completed state
+        self.assertEqual(Task.COMPLETED,
+                         workflow.get_tasks_from_spec_name('join')[0].state)
+
+    def test_join_conditional_not_ready_status_structured(self):
+        """ Test that a join is not considered complete if the all the tasks
+            are complete AND they were completed with the correct condition to
+            satisfy the join"""
+
+        workflow = self.setup_worflow()
+
+        workflow.complete_task_from_id(
+            workflow.get_tasks_from_spec_name('split')[0].id)
+        workflow.complete_task_from_id(
+            workflow.get_tasks_from_spec_name('first')[0].id)
+        choice_task = workflow.get_tasks_from_spec_name('choice')[0]
+
+        workflow.complete_task_from_id(choice_task.id)
+
+        # Join should be in waiting state NOT completed
+        self.assertEqual(Task.WAITING,
+                         workflow.get_tasks_from_spec_name('join')[
+                             0].state)
+
+    def test_join_conditional_not_ready_status_unstructured(self):
+        """ Test that a join is not considered complete if the all the tasks
+            are complete AND they were completed with the correct condition to
+            satisfy the join"""
+
+        workflow = self.setup_worflow(structured=False)
+
+        workflow.complete_task_from_id(
+            workflow.get_tasks_from_spec_name('split')[0].id)
+        workflow.complete_task_from_id(
+            workflow.get_tasks_from_spec_name('first')[0].id)
+        choice_task = workflow.get_tasks_from_spec_name('choice')[0]
+
+        workflow.complete_task_from_id(choice_task.id)
+
+        # Join should be in waiting state NOT completed
+        self.assertEqual(Task.WAITING,
+                         workflow.get_tasks_from_spec_name('join')[
+                             0].state)
 
 def suite():
     return unittest.TestLoader().loadTestsFromTestCase(JoinTest)


### PR DESCRIPTION
### The Problem

If you have a Join with a task added with `connect_if` and that task completes BUT **does not** satisfy the connect_if condition the Join still counts it as a "completed task" and will proceed to COMPLETED triggering. This will incorrectly trigger the next output.

Example:

```
ice_cream_join = Join('ice_cream_conditions')

is_friday = Simple('friday')
is_friday.connect(join)

ice_cream = Simple('get_ice_cream')
join.connect(ice_cream_join)

weather = Simple('weather')
default_bad_weather_task = Simple('buy_coffee')
weather.connect(bad_weather_task)
weather.connect_if(ice_cream_join, Equal(Attrib('sunny'), True)
```

If weather completes and it is Friday but it is NOT sunny `ice_cream_join` completes and triggers  `ice_cream` --> but `default_bad_weather_task` also triggers and completes `buy_coffee`.

### The Fix - The Good
Updated the logic in "Join" to not count any children tasks as "completed" UNLESS they also matched if the `connect_if` condition.

### The Fix - The Bad
Once this happens the Join is stuck forever in `WAITING` since the child task will never complete. I don't think this is harmful but I'm not totally convinced it is correct.

### Github Fork or internal repo?
I made this change here so that we could run the repositories test suites.

We could just as easily create a custom Join internally to our code base and use that.

https://github.com/knipknap/SpiffWorkflow has last modified 10 months ago so probably too early to call dead but too quiet to call active.

I'll let you the reviewers make this call 😏 
